### PR TITLE
release dstbuffer

### DIFF
--- a/DepthApp/DepthApp/DepthCapture.swift
+++ b/DepthApp/DepthApp/DepthCapture.swift
@@ -32,6 +32,12 @@ class DepthCapture {
     func reset() {
         frameCount = 0
         outputURL = nil
+        
+        if self.dstBuffer != nil {
+            self.dstBuffer!.deallocate()
+            self.dstBuffer = nil
+        }
+        
         if self.compresserPtr != nil {
             //free(compresserPtr!.pointee.dst_ptr)
             compression_stream_destroy(self.compresserPtr!)


### PR DESCRIPTION
when finish record, the dstbuffer not be dealloc, if repeat record video,  and write depth file, the memory will increased huge